### PR TITLE
Enable/Disable HTTP access is flexible now

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ After provisioning, don't forget to run commands below:
 * **ami_id:** Amazon Linux AMI ID
 * **instance_type:** Instance type of the VPN box (t2.small is mostly enough)
 * **whitelist:** List of office IP addresses that you can SSH and non-VPN connected users can reach temporary profile download pages
-* **internal_cidrs:** List of CIDRs that will be whitelisted to access the VPN server internally. _This option replaced the hard-coded 10.0.0.0/8 network range_
+* **whitelist_http:** List of IP addresses that you can allow HTTP connections.
+* **internal_cidrs:** List of CIDRs that will be whitelisted to access the VPN server internally.
 * **tags:** Map of AWS Tag key and values
 * **resource_name_prefix:** All the resources will be prefixed with the value of this variable
 * **healthchecks_io_key:** Health check key for healthchecks.io

--- a/main.tf
+++ b/main.tf
@@ -167,10 +167,13 @@ resource "aws_security_group" "pritunl" {
 
   # HTTP access for Let's Encrypt validation
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+
+    cidr_blocks = [
+      "${var.whitelist_http}",
+    ]
   }
 
   # HTTPS access
@@ -240,7 +243,7 @@ resource "aws_security_group" "allow_from_office" {
   ingress {
     description = "Allow ICMPv4 from select CIDRs"
     from_port   = -1
-    to_port   = -1
+    to_port     = -1
     protocol    = "icmp"
     cidr_blocks = ["${var.whitelist}"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "whitelist" {
   type        = "list"
 }
 
+variable "whitelist_http" {
+  description = "[List] Whitelist for HTTP port"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}


### PR DESCRIPTION
This PR covers #13 

So, at the time of Let's Encrypt confirmation can be enabled and can be disabled back easily if needed